### PR TITLE
Added AdjacentModel.NormalizeWeights and made SetFrequency/MultiplyFrequency optionally aware of RotatedTile

### DIFF
--- a/DeBroglie/Models/OverlappingModel.cs
+++ b/DeBroglie/Models/OverlappingModel.cs
@@ -151,8 +151,13 @@ namespace DeBroglie.Models
         public override IReadOnlyDictionary<int, Tile> PatternsToTiles => patternsToTiles;
         public override ILookup<Tile, int> TilesToPatterns => tilesToPatterns;
 
-        public override void MultiplyFrequency(Tile tile, double multiplier)
+        public override void MultiplyFrequency(Tile tile, double multiplier, bool includeRotatedTiles = false)
         {
+            Tile GetTile(Tile _tile)
+            {
+                return includeRotatedTiles ? GetUnrotatedTile(_tile) : _tile;
+            }
+
             for (var p = 0; p < patternArrays.Count; p++)
             {
                 var patternArray = patternArrays[p];
@@ -162,7 +167,7 @@ namespace DeBroglie.Models
                     {
                         for (var z = 0; z < patternArray.Depth; z++)
                         {
-                            if (patternArray.Values[x, y, z] == tile)
+                            if (GetTile(patternArray.Values[x, y, z]) == tile)
                             {
                                 frequencies[p] *= multiplier;
                             }
@@ -171,6 +176,14 @@ namespace DeBroglie.Models
                 }
             }
         }
-    }
 
+        private Tile GetUnrotatedTile(Tile tile)
+        {
+            if (tile.Value is RotatedTile rotatedTile)
+            {
+                return rotatedTile.Tile;
+            }
+            return tile;
+        }
+    }
 }

--- a/DeBroglie/Models/TileModel.cs
+++ b/DeBroglie/Models/TileModel.cs
@@ -33,6 +33,6 @@ namespace DeBroglie.Models
         /// <summary>
         /// Scales the the occurency frequency of a given tile by the given multiplier.
         /// </summary>
-        public abstract void MultiplyFrequency(Tile tile, double multiplier);
+        public abstract void MultiplyFrequency(Tile tile, double multiplier, bool includeRotatedTiles = false);
     }
 }


### PR DESCRIPTION
When using the AdjacencyModel via AddSample I have found it very useful to be able to normalize the weights of each tile afterwards. I do not find the concept makes much sense in the OverlappingModel so I have not attempted to implement that.

Additionally, I found myself wanting to multiply the frequency of a tile and not have to manually specify every rotated/reflected variant of it, so I modified MultiplyFrequency in both models to support dereferencing a RotatedTile to it's base representation.