### PR TITLE
Specify invariant culture when parsing doubles

### DIFF
--- a/DeBroglie.Console/Config/Factory.cs
+++ b/DeBroglie.Console/Config/Factory.cs
@@ -6,6 +6,7 @@ using DeBroglie.Tiled;
 using DeBroglie.Topo;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -208,11 +209,11 @@ namespace DeBroglie.Console.Config
                         double cfd;
                         if (cf.EndsWith("%"))
                         {
-                            cfd = double.Parse(cf.TrimEnd('%')) / 100;
+                            cfd = double.Parse(cf.TrimEnd('%'), CultureInfo.InvariantCulture) / 100;
                         }
                         else
                         {
-                            cfd = double.Parse(cf);
+                            cfd = double.Parse(cf, CultureInfo.InvariantCulture);
                         }
                         model.MultiplyFrequency(value, cfd, tileRotation);
                     }


### PR DESCRIPTION
I wanted to play around with WFC for a bit and the console version of this library seemed like a perfect match, I could however not get it to parse any of the config files without throwing an error. 

After some investigation it turns out it's due to me having my computer set to a Swedish locale, which means it uses comma as a decimal separator. The ``double.Parse()`` call heeds this and will promptly refuse to parse the config files. A small change to specify the Invariant culture fixes this issue. 